### PR TITLE
update Aug 19, 2017 Bug fixes

### DIFF
--- a/array_utils/mrbitget.pro
+++ b/array_utils/mrbitget.pro
@@ -14,8 +14,10 @@
 ; :Params:
 ;       A:          in, required, type=numeric
 ;                   Array for which bits are get.
-;       BIT:        in, required, type=integer
-;                   Bit to get
+;       BIT:        in, optional, type=integer, default=reverse(bindgen(maxbit)+1B)
+;                   Bit to get. If not provided and `A` is scalar, the state of all
+;                       possible bits for the given datatype will be returned, starting
+;                       at bit N and decreasing to bit 1.
 ;
 ; :Keywords:
 ;       TYPE:       in, required, type=string/integer
@@ -38,6 +40,7 @@
 ; :History:
 ;    Modification History::
 ;       2016/09/13  -   Written by Matthew Argall
+;       2017/04/03  -   If `A` is scalar, then `BIT` can be undefined. - MRA
 ;-
 function MrBitGet, A, bit, $
 TYPE=type
@@ -92,6 +95,9 @@ TYPE=type
 		'ULONG64':  maxBit = 64
 		else: message, 'Datatype unknown: "' + type + '.'
 	endcase
+	
+	;Default to checking all bits
+	if nA eq 1 && nBits eq 0 then bit = reverse(bindgen(maxBit)+1B)
 	
 	;Check valid bit value
 	if ~array_equal(bit gt 0 and bit le maxBit, 1) $

--- a/array_utils/mrbitset.pro
+++ b/array_utils/mrbitset.pro
@@ -5,7 +5,7 @@
 ;
 ; PURPOSE:
 ;+
-;   Set the value of a particular bit (e.g., 1=on, 0=off).
+;   Set the value of a particular bit (e.g., 1=on, 0=off). Note that Bit 1 is 2^0.
 ;
 ; :Params:
 ;       A:          in, required, type=numeric
@@ -36,6 +36,7 @@
 ; :History:
 ;    Modification History::
 ;       2016/09/13  -   Written by Matthew Argall
+;       2017/04/03  -   Handle case when A is scalar and BIT is an array. - MRA
 ;-
 function MrBitSet, A, bit, V, $
 TYPE=type
@@ -56,7 +57,7 @@ TYPE=type
 	if nA    gt 1 && nA    ne N then message, 'A has an incorrect number of elements.'
 	if nBits gt 1 && nBits ne N then message, 'BITS has an incorrect number of elements.'
 	if nV    gt 1 && nV    ne N then message, 'V has an incorrect number of elements.'
-	
+
 	;Make sure we have scalars
 	if nBits eq 1 then bit = bit[0]
 	if nV    eq 1 then V   = V[0]
@@ -106,6 +107,7 @@ TYPE=type
 
 	;Set the proper bit
 	result = A + 2^(bit-1) * tf_set - 2^(bit-1) * tf_unset
+	if nA eq 1 && nBits gt 1 then result = total(result, /PRESERVE_TYPE)
 
 	;Return
 	return, result

--- a/type_utils/mrisa.pro
+++ b/type_utils/mrisa.pro
@@ -121,6 +121,7 @@
 ;                           treatment of pointers and objects is limited to when they
 ;                           are scalars. - MRA
 ;       2016/07/22  -   Unintentional dependencies of NULL keyword on others. Fixed. - MRA
+;       2017/06/22  -   Scalars now register as rows and columns. - MRA
 ;-
 function MrIsA, x, type, $
  COLUMN  = column, $
@@ -264,7 +265,7 @@ function MrIsA, x, type, $
 ;-----------------------------------------------------
     if column then begin
         ;Two dimensions, the first being of size 1 (i.e. a 1xN array)
-        if x_size[0] eq 2 && x_size[1] eq 1 $
+        if x_size[0] eq 0 || (x_size[0] eq 2 && x_size[1] eq 1) $
             then tf_isa = 1 and tf_isa $
             else tf_isa = 0
     endif
@@ -375,7 +376,7 @@ function MrIsA, x, type, $
 ;-----------------------------------------------------
     if row then begin
         ;One dimension
-        if x_size[0] eq 1 $
+        if x_size[0] eq 0 || x_size[0] eq 1 $
             then tf_isa = 1 and tf_isa $
             else tf_isa = 0
     endif


### PR DESCRIPTION
  - FIX: MrBitGet- Can return all bits of scalar value.
  - FIX: MrBitSet- Can check multiple bits of scalar value.
  - FIX: MrPolarization- Indices of frequency range was sometimes wrong. Fixed.
  - FIX: MrResolve_All- Some objects not resolved unless previously compiled. Now look for __DEFINE modules. Helper functions without module by same name are ignored.
  - FIX: MrIsA- scalar values count as row and column vectors.